### PR TITLE
Bugfix: progress bar 초기 상태 값을 0으로 수정

### DIFF
--- a/src/components/Survey/ProgressBar/ProgressBar.tsx
+++ b/src/components/Survey/ProgressBar/ProgressBar.tsx
@@ -12,7 +12,7 @@ const TOTAL_LENGTH = 312;
 const TOTAL_STEP = 6;
 
 const ProgressBar = ({ step }: Props) => {
-  const [progress, setProgress] = useState(step * TOTAL_LENGTH - TOTAL_LENGTH / TOTAL_STEP);
+  const [progress, setProgress] = useState(0);
 
   useEffect(() => {
     setProgress((step * TOTAL_LENGTH) / TOTAL_STEP);


### PR DESCRIPTION
## Summary

- progress bar 진행률의 초기 상태를 0으로 수정


