### PR TITLE
Fix: 덤벨 이미지 크기때문에 발생한 뷰포트 가로스크롤 이슈 해결

### DIFF
--- a/src/pages/ExerciseRoutine/exerciseRoutine.module.scss
+++ b/src/pages/ExerciseRoutine/exerciseRoutine.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-flow: column nowrap;
   height: 100vh;
+  overflow: hidden;
   text-align: center;
 }
 


### PR DESCRIPTION
exerciseRoutine page에 overflow: hidden 속성을 주어 해결

Changes to be committed:
modified:   src/pages/ExerciseRoutine/exerciseRoutine.module.scss

## Summary

- 아래 스크린샷처럼 화면전체에 가로스크롤이 생겨 하얀 화면이 생기는것을 페이지에 overflow: hidden; 속성을 주어 해결
 
## Screenshot

- ![layout overflow ui](https://user-images.githubusercontent.com/71176945/141144879-38edfb48-393b-4c7f-a95c-26333f1f02d7.png)

