### PR TITLE
Fix: token.js에서의 에러 fix

### DIFF
--- a/src/pages/ExerciseRoutine/ExerciseRoutine.tsx
+++ b/src/pages/ExerciseRoutine/ExerciseRoutine.tsx
@@ -127,13 +127,13 @@ const recommendExerciseList: Exercise[] = [
 
 function ExerciseRoutine() {
   useEffect(() => {
-    function getServerToken() {
+    const getServerToken = () => {
       const options = {};
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       healthyup.getServerToken(options, (result_cd: any, result_msg: any, extra: any) => {
         console.log(result_cd + result_msg + JSON.stringify(extra));
       });
-    }
+    };
 
     getServerToken();
   }, []);

--- a/src/utils/mobile/token.js
+++ b/src/utils/mobile/token.js
@@ -13,7 +13,7 @@ healthyup.callNative = (functionName, options, callback) => {
   transactions[trx_id] = {};
   transactions[trx_id].call = callback;
   transactions[trx_id].options = options;
-  window.healthyup_native_api.call(functionName, JSON.stringify(options), trx_id);
+  window.healthyup_native_api?.call(functionName, JSON.stringify(options), trx_id);
 };
 
 healthyup.event = (_eventData) => {
@@ -25,7 +25,7 @@ healthyup.event = (_eventData) => {
 
 function pad(n, width) {
   const strN = n.toString();
-  return n.length >= width ? strN : new Array(width - n.length + 1).join('0') + strN;
+  return n.length >= width ? n : new Array(width - strN.length + 1).join('0') + n;
 }
 
 healthyup.getTransactionId = () => {


### PR DESCRIPTION


## Summary
- healthyup 함수의 call 프로퍼티에 대한 유무를 옵셔널체이닝으로 처리
- pad 함수내에서의 n.length참조에서 n이 number값이어서 발생하는 에러를 n을 string으로 변경
