### PR TITLE
Fix: response JSON을 stringify 후 parse 하게 변경

### DIFF
--- a/src/utils/mobile/token.js
+++ b/src/utils/mobile/token.js
@@ -45,11 +45,7 @@ const getServerToken = (options = {}) => {
         reject(new Error());
       }
 
-      console.log(`response: ${response}`);
-      const responseStr = JSON.stringify(response);
-      console.log(`responseStr: ${responseStr}`);
-      const responseObj = JSON.parse(response);
-      console.log(`responseObj: ${responseObj}`);
+      const responseObj = JSON.parse(JSON.stringify(response));
       resolve(responseObj.serverToken ?? '');
     });
   });


### PR DESCRIPTION
## Summary

- JSON parse에 string값이 아닌 JSON Object가 전달되고 있어 발생하는 오류를 stringify를 사용하여 해결