### PR TITLE
Feature/modal dialog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,5 +14,6 @@
       >이 사이트를 이용하려면? 사용 중인 웹 브라우저에서 JavaScript를 활성화 해야 합니다.</noscript
     >
     <div id="app"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/src/components/ExerciseChoice/ExerciseModifyConfirmDialog/ExerciseModifyConfirmDialog.tsx
+++ b/src/components/ExerciseChoice/ExerciseModifyConfirmDialog/ExerciseModifyConfirmDialog.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import classNames from 'classnames';
+import { ConfirmModalDialog } from '@/components';
+import style from './exerciseModifyConfirmDialog.module.scss';
+
+interface Props {
+  handleCancel: React.MouseEventHandler<HTMLButtonElement>;
+  handleApprove: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const { s_title, s_description } = style;
+
+const ExerciseModifyConfirmDialog = ({ handleCancel, handleApprove }: Props) => {
+  return (
+    <ConfirmModalDialog handleCancel={handleCancel} handleApprove={handleApprove}>
+      <span className={classNames(s_title, 's_whiteSpace')}>운동부위를 변경하시겠어요?</span>
+      <span className={classNames(s_description)}>운동 부위를 변경하면</span>
+      <span className={classNames(s_description, 's_whiteSpace')}>선택한 운동이 초기화 돼요</span>
+    </ConfirmModalDialog>
+  );
+};
+
+export default React.memo(ExerciseModifyConfirmDialog);

--- a/src/components/ExerciseChoice/ExerciseModifyConfirmDialog/exerciseModifyConfirmDialog.module.scss
+++ b/src/components/ExerciseChoice/ExerciseModifyConfirmDialog/exerciseModifyConfirmDialog.module.scss
@@ -1,0 +1,15 @@
+@use '@/styles/color';
+
+.s_title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: -0.05rem;
+  line-height: 3.1rem;
+  margin-bottom: 1.6rem;
+}
+
+.s_description {
+  color: color.$primaryVariant4;
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+}

--- a/src/components/ExerciseChoice/index.ts
+++ b/src/components/ExerciseChoice/index.ts
@@ -1,0 +1,1 @@
+export { default as ExerciseModifyConfirmDialog } from './ExerciseModifyConfirmDialog/ExerciseModifyConfirmDialog';

--- a/src/components/common/ConfirmModalDialog/ConfirmModalDialog.tsx
+++ b/src/components/common/ConfirmModalDialog/ConfirmModalDialog.tsx
@@ -1,0 +1,32 @@
+import React, { ReactNode } from 'react';
+import classNames from 'classnames';
+import { Modal } from '@/components';
+import style from './confirmModalDialog.module.scss';
+
+interface Props {
+  handleCancel: React.MouseEventHandler<HTMLButtonElement>;
+  handleApprove: React.MouseEventHandler<HTMLButtonElement>;
+  children: ReactNode;
+}
+
+const { s_alertDialog, s_confirmButtons, s_cancelButton, s_approvalButton } = style;
+
+const ConfirmModalDialog = ({ handleCancel, handleApprove, children }: Props) => {
+  return (
+    <Modal>
+      <div className={classNames(s_alertDialog)}>
+        {children}
+        <div className={classNames(s_confirmButtons)}>
+          <button type="button" className={classNames(s_cancelButton)} onClick={handleCancel}>
+            취소
+          </button>
+          <button type="button" className={classNames(s_approvalButton)} onClick={handleApprove}>
+            확인
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmModalDialog;

--- a/src/components/common/ConfirmModalDialog/confirmModalDialog.module.scss
+++ b/src/components/common/ConfirmModalDialog/confirmModalDialog.module.scss
@@ -1,0 +1,44 @@
+@use '@/styles/color';
+
+.s_alertDialog {
+  background-color: #fff;
+  border-radius: 1.6rem;
+  border-bottom-right-radius: 1.9rem;
+  filter:
+    drop-shadow(0 3px 13px rgba(0, 0, 0, 0.039))
+    drop-shadow(0 10.5px 36px rgba(0, 0, 0, 0.19));
+  height: 22.8rem;
+  left: 50%;
+  padding: 4rem 2.4rem 0 2.4rem;
+  position: relative;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  transform: translate3d(-50%, -50%, 0);
+  width: 31.2rem;
+
+  .s_confirmButtons {
+    bottom: 0;
+    height: 54px;
+    left: 0;
+    position: absolute;
+    width: 100%;
+
+    .s_cancelButton {
+      background-color: color.$onBackground4;
+      border-bottom-left-radius: 1.6rem;
+      height: 100%;
+      padding: 0;
+      width: 50%;
+    }
+
+    .s_approvalButton {
+      background-color: color.$primary;
+      border-bottom-right-radius: 1.6rem;
+      color: color.$onPrimary;
+      height: 100%;
+      padding: 0;
+      width: 50%;
+    }
+  }
+}

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,32 @@
+import classNames from 'classnames';
+import React, { ReactNode, useEffect } from 'react';
+import Portal from '../Portal/Portal';
+import style from './modal.module.scss';
+
+interface Props {
+  children: ReactNode;
+}
+
+const { s_modal } = style;
+
+const Modal = ({ children }: Props) => {
+  useEffect(() => {
+    const $rootNode = document.getElementById('app');
+    $rootNode?.setAttribute('aria-hidden', 'true');
+
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      $rootNode?.removeAttribute('aria-hidden');
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  return (
+    <Portal elementId="modal-root">
+      <div className={classNames(s_modal)}>{children}</div>
+    </Portal>
+  );
+};
+
+export default Modal;

--- a/src/components/common/Modal/modal.module.scss
+++ b/src/components/common/Modal/modal.module.scss
@@ -1,0 +1,11 @@
+@use '@/styles/color';
+
+.s_modal {
+  background: rgba(0, 0, 0, 0.6);
+  height: 100vh;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 10000;
+}

--- a/src/components/common/Portal/Portal.tsx
+++ b/src/components/common/Portal/Portal.tsx
@@ -1,0 +1,14 @@
+import React, { ReactNode } from 'react';
+import ReactDOM from 'react-dom';
+
+interface Props {
+  children: ReactNode;
+  elementId: string;
+}
+
+const Portal = ({ children, elementId }: Props) => {
+  const $el = document.getElementById(elementId) as HTMLElement;
+  return ReactDOM.createPortal(children, $el);
+};
+
+export default Portal;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -6,3 +6,4 @@ export { default as CustomLabel } from './CustomLabel/CustomLabel';
 export { default as CustomInput } from './CustomInput/CustomInput';
 export { default as Loading } from './Loading/Loading';
 export { default as Portal } from './Portal/Portal';
+export { default as Modal } from './Modal/Modal';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,3 +5,4 @@ export { default as Tabs } from './Tabs/Tabs';
 export { default as CustomLabel } from './CustomLabel/CustomLabel';
 export { default as CustomInput } from './CustomInput/CustomInput';
 export { default as Loading } from './Loading/Loading';
+export { default as Portal } from './Portal/Portal';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -7,3 +7,4 @@ export { default as CustomInput } from './CustomInput/CustomInput';
 export { default as Loading } from './Loading/Loading';
 export { default as Portal } from './Portal/Portal';
 export { default as Modal } from './Modal/Modal';
+export { default as ConfirmModalDialog } from './ConfirmModalDialog/ConfirmModalDialog';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './ExerciseRoutine';
 export * from './common';
 export * from './Survey';
+export * from './ExerciseChoice';


### PR DESCRIPTION
## Summary

- 범용적으로 사용 할 Modal 컴포넌트를 만들었습니다. Portal을 이용하여 DOM트리상에서 #app과 분리했습니다.
- 확인, 취소 버튼이 존재하는 ConfirmModalDialog 컴포넌트를 만들었습니다. 취소, 확인 액션에 대한 함수를 정의하여 props로 전달하여 사용할 수 있습니다. 그 이외의 다이얼로그 내부의 UI는 자유도 높게 만들어줄 수 있게 children으로 전달받게끔 구현하였습니다.
- 운동변경 페이지에서 사용될 모달 다이얼로그를 ConfirmModalDialog컴포넌트를 이용하여 만들었습니다. 운동변경 페이지의 상단탭에서 다른 운동 부위를 선택하려고 할때 띄워질때 사용할 수 있습니다.

사용 예시는 아래와 같습니다. 모달 open에 대한 상태를 만들고 그것을 이벤트 리스너로 컨트롤 하게끔 하여 props로 해당 이벤트 리스너를 전달하는 패턴입니다.
```tsx
...other code...

const ExerciseRoutine = () => {
  const [isModalOepn, setIsModalOpen] = useState(false);

  const handleModelOpen = () => {
    setIsModalOpen(true);
  };

  const handleModalClose = useCallback(() => {
    setIsModalOpen(false);
  }, []);

  return (
  <>
    <button type="button" onClick={handleModelOpen}>
      모달 오픈
    </button>
    {isModalOepn && (
      <ExerciseModifyConfirmDialog handleApprove={() => {}} handleCancel={handleModalClose} />
    )}
  </>
  );
}

export default ExerciseRoutine;

```

## Screenshot
아래와 같은 뷰가 나와야합니다. 다이얼로그의 디자인은 변경될걸로 예상됩니다.
![운동부위 변경 확인 모달 다이얼로그](https://user-images.githubusercontent.com/71176945/144123869-62a3a017-c334-45e6-9e35-834dfdd89d61.png)

