### PR TITLE
Fix: Survey 라우트 렌더링 이슈와 historypop시 step이 고정되어 있는 이슈

### DIFF
--- a/src/pages/Survey/Survey.tsx
+++ b/src/pages/Survey/Survey.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { Route, useHistory } from 'react-router-dom';
 import { SURVEY_PAGE } from '@/consts';
@@ -55,10 +55,9 @@ const Survey = () => {
   const { surveyState, setSurveyStateByKey } = useSurveyForm();
 
   const handleSetPreviousPage = () => {
-    if (step <= MIN_STEP) return;
-    setStep((previousStep) => previousStep - 1);
     history.goBack();
   };
+
   const handleSetNextPage = (nextPageUrl: string) => () => {
     if (step > MAX_STEP) return;
 
@@ -66,15 +65,24 @@ const Survey = () => {
     history.push(nextPageUrl);
   };
 
-  if (step === 0)
+  useEffect(() => {
+    const handleDecreaseStep = () => {
+      setStep((previousStep) => previousStep - 1);
+    };
+    window.addEventListener('popstate', handleDecreaseStep);
+    return () => {
+      window.removeEventListener('popstate', handleDecreaseStep);
+    };
+  }, []);
+
+  if (step === 0) {
     return (
-      <Route path={SURVEY_PAGE_COLLECTION.INTRO}>
-        <Intro
-          handleClickStartButton={handleSetNextPage(SURVEY_PAGE_COLLECTION.NICKNAME)}
-          buttonType="start"
-        />
-      </Route>
+      <Intro
+        handleClickStartButton={handleSetNextPage(SURVEY_PAGE_COLLECTION.NICKNAME)}
+        buttonType="start"
+      />
     );
+  }
 
   if (step > MAX_STEP) {
     return (

--- a/src/pages/Survey/Survey.tsx
+++ b/src/pages/Survey/Survey.tsx
@@ -38,12 +38,12 @@ const SURVEY_PAGE_COLLECTION = {
   NICKNAME: `${SURVEY_PAGE}/nickname`,
   GENDER: `${SURVEY_PAGE}/gender`,
   AGE: `${SURVEY_PAGE}/age`,
-  SPLITTYPE: `${SURVEY_PAGE}/split-type`,
-  BODYINFO: `${SURVEY_PAGE}/body-info`,
-  AUDIOCOACH: `${SURVEY_PAGE}/audio-coach`,
-  EXERCISESPEED: `${SURVEY_PAGE}/exercise-speed`,
-  AUDIOEXPLANATION: `${SURVEY_PAGE}/audio-explanation`,
-  SURVEYCOMPLETE: `${SURVEY_PAGE}/survey-complete`,
+  SPLIT_TYPE: `${SURVEY_PAGE}/split-type`,
+  BODY_INFO: `${SURVEY_PAGE}/body-info`,
+  AUDIO_COACH: `${SURVEY_PAGE}/audio-coach`,
+  EXERCISE_SPEED: `${SURVEY_PAGE}/exercise-speed`,
+  AUDIO_EXPLANATION: `${SURVEY_PAGE}/audio-explanation`,
+  SURVEY_COMPLETE: `${SURVEY_PAGE}/survey-complete`,
 };
 
 const MIN_STEP = 0;
@@ -86,7 +86,7 @@ const Survey = () => {
 
   if (step > MAX_STEP) {
     return (
-      <Route path={SURVEY_PAGE_COLLECTION.SURVEYCOMPLETE}>
+      <Route path={SURVEY_PAGE_COLLECTION.SURVEY_COMPLETE}>
         <SurveyComplete surveyState={surveyState} buttonType="letsGo" />;
       </Route>
     );
@@ -120,50 +120,50 @@ const Survey = () => {
               nickname={surveyState.nickname}
               age={surveyState.age}
               setAge={setSurveyStateByKey(SURVEY_STATE_KEY.AGE)}
-              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.BODYINFO)}
+              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.BODY_INFO)}
               buttonType="next"
             />
           </Route>
-          <Route path={SURVEY_PAGE_COLLECTION.BODYINFO}>
+          <Route path={SURVEY_PAGE_COLLECTION.BODY_INFO}>
             <BodyInfo
               nickname={surveyState.nickname}
               height={surveyState.height}
               setHeight={setSurveyStateByKey(SURVEY_STATE_KEY.HEIGHT)}
               weight={surveyState.weight}
               setWeight={setSurveyStateByKey(SURVEY_STATE_KEY.WEIGHT)}
-              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.SPLITTYPE)}
+              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.SPLIT_TYPE)}
               buttonType="next"
             />
           </Route>
-          <Route path={SURVEY_PAGE_COLLECTION.SPLITTYPE}>
+          <Route path={SURVEY_PAGE_COLLECTION.SPLIT_TYPE}>
             <SplitType
               splitType={surveyState.splitType}
               setSplitType={setSurveyStateByKey(SURVEY_STATE_KEY.SPLIT_TYPE)}
-              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.AUDIOCOACH)}
+              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.AUDIO_COACH)}
               buttonType="next"
             />
           </Route>
-          <Route path={SURVEY_PAGE_COLLECTION.AUDIOCOACH}>
+          <Route path={SURVEY_PAGE_COLLECTION.AUDIO_COACH}>
             <AudioCoach
               audioCoach={surveyState.audioCoach}
               setAudioCoach={setSurveyStateByKey(SURVEY_STATE_KEY.AUDIO_COACH)}
-              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.EXERCISESPEED)}
+              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.EXERCISE_SPEED)}
               buttonType="next"
             />
           </Route>
-          <Route path={SURVEY_PAGE_COLLECTION.EXERCISESPEED}>
+          <Route path={SURVEY_PAGE_COLLECTION.EXERCISE_SPEED}>
             <ExerciseSpeed
               exerciseSpeed={surveyState.speed}
               setExerciseSpeed={setSurveyStateByKey(SURVEY_STATE_KEY.SPEED)}
-              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.AUDIOEXPLANATION)}
+              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.AUDIO_EXPLANATION)}
               buttonType="next"
             />
           </Route>
-          <Route path={SURVEY_PAGE_COLLECTION.AUDIOEXPLANATION}>
+          <Route path={SURVEY_PAGE_COLLECTION.AUDIO_EXPLANATION}>
             <AudioExplanation
               needDetailExplanation={surveyState.explanation}
               setNeedDetailExplanation={setSurveyStateByKey(SURVEY_STATE_KEY.EXPLANATION)}
-              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.SURVEYCOMPLETE)}
+              handleClickCustomEvent={handleSetNextPage(SURVEY_PAGE_COLLECTION.SURVEY_COMPLETE)}
               buttonType="complete"
             />
           </Route>

--- a/src/pages/Survey/Survey.tsx
+++ b/src/pages/Survey/Survey.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { Route, useHistory } from 'react-router-dom';
 import { SURVEY_PAGE } from '@/consts';


### PR DESCRIPTION
## Summary

- historypop시에 step이 조정되지 않아 프로그래스바 및 현재 렌더링 되어야하는 페이지의 상태값이 관리되지 않는 이슈를 해결하였습니다.

fix후의 동작은 영상으로 HelltaBus 웹팀 단톡방에 남겨놓았습니다.
