### PR TITLE
Fix/exercise choice scroll x

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,7 +1,0 @@
-.container {
-  background-color: #e7e3eb;
-  height: 100vh;
-  h1 {
-    color: #6200ee;
-  }
-}

--- a/src/components/ExerciseChoice/ExercisePartCarousel/exercisePartCarousel.module.scss
+++ b/src/components/ExerciseChoice/ExercisePartCarousel/exercisePartCarousel.module.scss
@@ -5,7 +5,10 @@
 .s_customCarousel {
   background-color: rgba(0, 0, 0, 0);
   margin-bottom: 2.8rem;
-  padding-left: 2.4rem;
+  padding: {
+    left: 2.4rem;
+    right: 1.4rem;
+  }
 }
 
 .s_notSelectedExerciseCard {

--- a/src/components/common/Carousel/Carousel.tsx
+++ b/src/components/common/Carousel/Carousel.tsx
@@ -7,14 +7,18 @@ interface CarouselProps {
   className?: string;
 }
 
-const { s_carousel } = style;
+const { s_carousel, s_carouselItem } = style;
 
 function Carousel({ children, className }: CarouselProps) {
   return (
     <ul className={classNames(s_carousel, className)}>
       {Array.isArray(children)
         ? children.map((child, index) => {
-            return <li key={`carouselItem-${index}`}>{child}</li>;
+            return (
+              <li className={classNames(s_carouselItem)} key={`carouselItem-${index}`}>
+                {child}
+              </li>
+            );
           })
         : null}
     </ul>

--- a/src/components/common/Carousel/carousel.module.scss
+++ b/src/components/common/Carousel/carousel.module.scss
@@ -7,3 +7,7 @@
     display: none;
   }
 }
+
+.s_carouselItem {
+  position: relative;
+}

--- a/src/pages/ExerciseChoice/ExerciseChoice.tsx
+++ b/src/pages/ExerciseChoice/ExerciseChoice.tsx
@@ -20,11 +20,11 @@ const ExerciseChoice = () => {
       />
       {tabHeaders && tabPanels ? (
         <Tabs headers={tabHeaders}>
-          {tabPanels.map((exerciseParts) => (
-            <div className={classNames(s_exerciseTabPanel)}>
-              {exerciseParts.map(({ part, exercises }, index) => (
+          {tabPanels.map((exerciseParts, index) => (
+            <div className={classNames(s_exerciseTabPanel)} key={`tabPanel-${index}`}>
+              {exerciseParts.map(({ part, exercises }) => (
                 <ExercisePartCarousel
-                  key={`exercisePartCarousel-${index}`}
+                  key={`exercisePartCarousel-${part}`}
                   partName={part}
                   exercises={exercises}
                   selectedExercises={selectedExercises}


### PR DESCRIPTION
## Summary

- ExercisePartCarousel이 상위요소의 width를 넘어가 overflow되는 현상을 수정했습니다.
- ExercisePartCarousel의 마지막 요소를 클릭했을때 뷰가 깨지는 버그를 수정했습니다.
- ExerciseChoice페이지 컴포넌트에서 렌더링 되는 tabPanels.map 구문의 리스트 렌더링에 빠진 key props를 추가해주었습니다.
- 사용하지 않는 app.scss파일을 삭제해주었습니다.

## Screenshot

- HelltaBus 웹팀 카톡방에 영상으로 첨부했습니다.
