### PR TITLE
Modify: 운동 설명 순서 사이의 margin값 수정 (디자인 시안 변경)

### DIFF
--- a/src/components/common/ExerciseDescriptionModalDialog/exerciseDescriptionModalDialog.module.scss
+++ b/src/components/common/ExerciseDescriptionModalDialog/exerciseDescriptionModalDialog.module.scss
@@ -53,6 +53,6 @@
   font-size: 1.4rem;
   font-weight: 400;
   line-height: 1.9rem;
-  margin: 4px 0;
+  margin: 8px 0;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
## Summary

- 디자인 시안 변경에 따른 운동 설명 순서 사이의 margin값을 수정했습니다.

## ScreenShot

![](https://user-images.githubusercontent.com/71176945/144995195-1ace1765-efea-451d-9cef-2d41b7bc3c73.png)
