### PR TITLE
Refactor: 폰트 로딩속도 개선 css import -> html link로 변경

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,10 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1, user-scalable=0"
     />
-
+    <link
+      rel="stylesheet"
+      href="https://gif.helltabus.com/libs/spoqa-han-sans-neo/css/SpoqaHanSansNeo-kr.css"
+    />
     <title>Helltabus</title>
   </head>
   <body>

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -1,7 +1,5 @@
 @use './color';
 
-@import url('https://gif.helltabus.com/libs/spoqa-han-sans-neo/css/SpoqaHanSansNeo-kr.css');
-
 /**
  * 사용자 정의 초기화
  */


### PR DESCRIPTION
## Summary

- font를 css import, html link를 테스트 해봤을때 유의미한 변화가 보여 html link태그로 불러오게끔 수정해주었습니다.

## ScreenShot

- CSS import - Network setting = Slow 3G
대기열 시작 지점 평균 4.27초 (3번의 테스트)
![](https://user-images.githubusercontent.com/71176945/145383887-2c9abf2e-d99b-4053-9baa-2fe5629199d2.png)
![](https://user-images.githubusercontent.com/71176945/145383954-112fe458-7274-4ac5-8c28-49def4ce9e5c.png)
![](https://user-images.githubusercontent.com/71176945/145383976-6c9464d6-cd22-450d-aa84-374fd7b641f2.png)

- HTML link tag - Network setting = Slow 3G
대기열 시작 지점 평균 2.09초 (3번의 테스트)
![](https://user-images.githubusercontent.com/71176945/145384245-98ee9fc0-a880-46f5-867b-fe3d2502b0cf.png)
![](https://user-images.githubusercontent.com/71176945/145384275-a95aeebb-8ed9-4f05-bc0e-855a5adc4f2d.png)
![](https://user-images.githubusercontent.com/71176945/145384290-b8370a67-2755-4aa6-b665-9e84b7264759.png)

- CSS import - Network setting = No Throttle (평소와 같은 사용 환경)
대기열 시작 지점 평균 294.38ms (3번의 테스트)
![](https://user-images.githubusercontent.com/71176945/145384551-3dcec951-3257-4a07-8715-617b1391fe78.png)
![](https://user-images.githubusercontent.com/71176945/145384569-aa059d7e-70cc-45c9-9f92-0f721e604c43.png)
![](https://user-images.githubusercontent.com/71176945/145384581-1ba4cee9-805e-46cd-96e9-9a16fb33adad.png)

- HTML link tag - Network setting = No Throttle (평소와 같은 사용 환경)
대기열 시작 지점 평균 46.7ms (수치가 워낙 작아서 편차가 크기 때문에 5번의 테스트를 기준으로 하였음)
![](https://user-images.githubusercontent.com/71176945/145384986-ef8f3a0a-5021-4972-ba85-b25cd5edbc45.png)
![](https://user-images.githubusercontent.com/71176945/145385006-a5d873dc-8fbe-4063-a3d7-e96b652d5164.png)
![](https://user-images.githubusercontent.com/71176945/145385026-5759d51f-ebcc-4475-b150-e0d31ba00e44.png)
![](https://user-images.githubusercontent.com/71176945/145385046-e522732e-b204-4f05-a4f6-a210032a91e9.png)
![](https://user-images.githubusercontent.com/71176945/145384971-92a22704-6b76-407d-9b95-73f6b18bce15.png)


결론은 현재의 구조에서 index.scss는 react의 index.tsx에서 불리고 있기 때문에 두 방법에서 폰트 파일을 요청하는 시점이 다릅니다. 그래서 네트워크 속도 제한없이 link태그로 요청했을시 워낙 ms단위가 작아서 편차가 좀 있어보이지만 css import방식보단 절대적으로 빠른 모습을 보여줍니다.

