### PR TITLE
Fix: splitType을 바꾸고 HOME페이지에 가도 적용되지 않는 버그 수정

### DIFF
--- a/src/hooks/page/useSplitTypeChange.ts
+++ b/src/hooks/page/useSplitTypeChange.ts
@@ -1,9 +1,11 @@
 import { useHistory } from 'react-router-dom';
+import { useQueryClient } from 'react-query';
 import { useFetchUserInfo, usePatchUserInfo } from '@/hooks';
 import { SplitType, User } from '@/types';
 
 const useSplitTypeChange = () => {
   const history = useHistory();
+  const queryClient = useQueryClient();
   const { error: userInfoError, isError: isUserInfoError, userInfo } = useFetchUserInfo();
 
   const { age, audioCoach, explanation, gender, height, nickname, speed, weight } =
@@ -14,7 +16,12 @@ const useSplitTypeChange = () => {
     isError: isPatchUserError,
     isLoading: isPatchUserInfoLoading,
     mutate,
-  } = usePatchUserInfo({ onSuccess: () => history.goBack() });
+  } = usePatchUserInfo({
+    onSuccess: () => {
+      queryClient.invalidateQueries('userInfo');
+      history.goBack();
+    },
+  });
 
   const patchUserInfo = (splitType: SplitType | '') => {
     const newUserInfo = {


### PR DESCRIPTION
## Summary

- userInfo를 useMutation으로 mutate한 이후 userInfo의 fetch가 다시 일어나지 않아 업데이트후에 상태가 서버와 동기화되지 않는 이슈를 invalidateQueries함수를 사용하여 해결하였습니다.

ps. 현재 웹 환경에서는 이슈가 해결되었는데 앱 환경에서는 해결이 안될수도 있을것 같습니다. 이유로는 HOME페이지와 분할변경 페이지가 네이티브에서 다른 웹뷰에 뜨기 때문에 분할변경 웹뷰에서 최신화를 요청해도 HOME 웹뷰에서는 알 수 없을수도 있기 때문입니다.