### PR TITLE
Feat: splitType 업데이트 후 업데이트 여부와 값을 네이티브에 전달

### DIFF
--- a/src/hooks/api/usePatchUserInfo.ts
+++ b/src/hooks/api/usePatchUserInfo.ts
@@ -1,9 +1,11 @@
 import { useMutation } from 'react-query';
 import { patchUserInfo } from '@/api';
-import { SurveyFields } from '@/types';
+import { SurveyFields, User } from '@/types';
 
 interface Options {
-  onSuccess: () => void;
+  onSuccess:
+    | ((data: User, variables: SurveyFields, context: unknown) => void | Promise<unknown>)
+    | undefined;
 }
 
 const usePatchUserInfo = ({ onSuccess }: Options) => {

--- a/src/hooks/page/useSplitTypeChange.ts
+++ b/src/hooks/page/useSplitTypeChange.ts
@@ -15,10 +15,11 @@ const useSplitTypeChange = () => {
     isLoading: isPatchUserInfoLoading,
     mutate,
   } = usePatchUserInfo({
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries('userInfo');
+
       setBackButtonReceive(
-        { target: 'android' },
+        { target: 'android', isUpdated: true, updatedSplitType: data.splitType },
         (result_cd: string, result_msg: string, extra: JSON) => {
           console.log(result_cd + result_msg + JSON.stringify(extra));
         }


### PR DESCRIPTION
## Summary

- splitType 업데이트 후 업데이트 여부와 값을 네이티브에 전달합니다.
형식은 아래와 같습니다. 의사코드니 의도만 파악해주셨으면 좋을거 같아요 :)

```tsx
options = {
  target: 'andriod',
  isUpdated: true | false,
  updatedSplitType: 'FULL_BODY_WORKOUT' | 'SPLIT_3_DAY_WORKOUT' | 'SPLIT_5_DAY_WORKOUT'
}
```